### PR TITLE
Resize callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,50 @@ Install using npm:
 
 ## Usage
 
+```js
+var resizabull = require('resizabull'),
+    element = document.getElementById('resize-me'),
+    resizer = resizabull(element);
+```
+
 ## Available Options
+
+#### `options.onResizeStart(resizer)`
+
+Callback fired when a resize event has begun, receiving the `resizer` instance
+itself as an argument.
+
+#### `options.onResize(resizer)`
+
+Callback fired when a resize has started and an edge has been moved, receiving
+the `resizer` instance itself as an argument.
+
+#### `options.onResizeStop(resizer)`
+
+Callback fired when a resize event has ended, receiving the `resizer` instance
+itself as an argument.
+
+#### `options.threshold` (default: 5)
+
+Tolerance, in pixels, for how far the mouse cursor may be from the edge of a
+resizable element before the edge becomes draggable.
+
+## Methods
+
+The `resizabull` method returns a "resizer" instance with a number of methods:
+
+#### `resizer#bindEvents()`
+
+Method to add needed event listeners associated with the given __resizabull__
+instance to the DOM.
+
+NOTE: This method does not need to be called on newly instantiated resizers;
+this is done automatically.
+
+#### `resizer#unbindEvents()`
+
+Method to remove all event listeners associated with the given __resizabull__
+instance from the DOM.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var store = new Store({ window: window, document: document });
 store.bindEvents();
 store.render();
 
-function resizabull(el) {
-    var resizer = new Resizer(el);
+function resizabull(el, options) {
+    var resizer = new Resizer(el, options);
     store.add(resizer);
     resizer.bindEvents();
     return resizer;

--- a/lib/resizer.js
+++ b/lib/resizer.js
@@ -5,23 +5,31 @@ var helpers = require('./helpers');
 var getCursorState = helpers.getCursorState;
 var getGrabState = helpers.getGrabState;
 var isResizing = helpers.isResizing;
+var defaultOptions = {
+    threshold: 5
+};
+var initialState = {
+    grab: null,
+    x: null,
+    y: null,
+    isResizing: false,
+    onTopEdge: false,
+    onRightEdge: false,
+    onBottomEdge: false,
+    onLeftEdge: false
+};
 
 function Resizer(el, options) {
-    this.onDown = this.onDown.bind(this);
-    this.onTouchDown = this.onTouchDown.bind(this);
+    options = assign({}, defaultOptions, options);
 
-    options = options || {};
+    ['onDown', 'onTouchDown'].forEach(function(methodName) {
+        this[methodName] = this[methodName].bind(this);
+    }, this);
+
+    assign(this, initialState);
 
     this.el = el;
-    this.threshold = Number(options.threshold || 5);
-    this.grab = null;
-    this.x = null;
-    this.y = null;
-    this.isResizing = false;
-    this.onTopEdge = false;
-    this.onRightEdge = false;
-    this.onBottomEdge = false;
-    this.onLeftEdge = false;
+    this.threshold = Number(options.threshold);
 }
 
 Resizer.prototype.bindEvents = function() {

--- a/lib/resizer.js
+++ b/lib/resizer.js
@@ -5,7 +5,11 @@ var helpers = require('./helpers');
 var getCursorState = helpers.getCursorState;
 var getGrabState = helpers.getGrabState;
 var isResizing = helpers.isResizing;
+var noop = function() {};
 var defaultOptions = {
+    onResizeStart: noop,
+    onResize: noop,
+    onResizeStop: noop,
     threshold: 5
 };
 var initialState = {
@@ -30,6 +34,9 @@ function Resizer(el, options) {
 
     this.el = el;
     this.threshold = Number(options.threshold);
+    ['onResizeStart', 'onResize', 'onResizeStop'].forEach(function(opt) {
+        this[opt] = options[opt];
+    }, this);
 }
 
 Resizer.prototype.bindEvents = function() {
@@ -48,6 +55,8 @@ Resizer.prototype.onDown = function(e) {
 
     assign(this, state, { isResizing: isResizing(state) });
     this.grab = getGrabState(e, rect, this.threshold);
+
+    this.onResizeStart(this);
 };
 
 Resizer.prototype.onTouchDown = function(e) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -24,6 +24,7 @@ function updateState(e, resizer) {
 function updateResizerState(e) {
     return function(resizer) {
         updateState(e, resizer);
+        resizer.onResize(resizer);
     };
 }
 
@@ -31,6 +32,7 @@ function endResize(e) {
     return function(resizer) {
         updateState(e, resizer);
         resizer.grab = null;
+        resizer.onResizeStop(resizer);
     };
 }
 

--- a/test/resizer.test.js
+++ b/test/resizer.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var test = require('tape');
+var sinon = require('sinon');
 var Resizer = require('../lib/resizer');
 var createEl = require('./spec_util').createEl;
 
@@ -18,6 +19,9 @@ test('new resizer instance', function(t) {
     t.equal(subject.onRightEdge, false);
     t.equal(subject.onBottomEdge, false);
     t.equal(subject.onLeftEdge, false);
+    t.ok(typeof subject.onResizeStart === 'function');
+    t.ok(typeof subject.onResize === 'function');
+    t.ok(typeof subject.onResizeStop === 'function');
     t.end();
 });
 
@@ -59,10 +63,12 @@ test('onDown', function(t) {
         var subject = new Resizer(createEl());
         var e = { clientX: opts.x || 0, clientY: opts.y || 0 };
 
+        sinon.stub(subject, 'onResizeStart');
         subject.onDown(e);
 
         t.equal(subject.isResizing, expected, msg);
         t.ok(subject.grab);
+        t.ok(subject.onResizeStart.calledWith(subject));
     }
 
     testcase({ x:  50, y:  50 }, false, 'isResizing false when not on edge');

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -94,9 +94,11 @@ test('onMove', function(t) {
     var subject = new Store(getEnv());
     var e = { clientX: 10, clientY: 10 };
     var resizer1 = { threshold: 5,
-                     el: createEl({ t: 10, l: 10 }) };
+                     el: createEl({ t: 10, l: 10 }),
+                     onResize: sinon.stub() };
     var resizer2 = { threshold: 4,
-                     el: createEl({ t: 400, l: 0 }) };
+                     el: createEl({ t: 400, l: 0 }),
+                     onResize: sinon.stub() };
 
     var expectedState1 = getCursorState(
         e, resizer1.el.getBoundingClientRect(), resizer1.threshold);
@@ -113,6 +115,8 @@ test('onMove', function(t) {
         t.equal(resizer2[prop], expectedState2[prop]);
     });
     t.equal(subject.shouldRedraw, true, 'should trigger redraw');
+    t.ok(resizer1.onResize.calledWith(resizer1), 'should call onResize');
+    t.ok(resizer2.onResize.calledWith(resizer2), 'should call onResize');
 
     t.end();
 });
@@ -121,7 +125,8 @@ test('onUp', function(t) {
     var subject = new Store(getEnv());
     var e = { clientX: 400, clientY: 400 };
     var resizer = { threshold: 5,
-                    el: createEl({ t: 10, l: 10 }) };
+                    el: createEl({ t: 10, l: 10 }),
+                    onResizeStop: sinon.stub() };
 
     resizer.grab = {};
 
@@ -133,6 +138,7 @@ test('onUp', function(t) {
             t.ok(resizer[prop] !== undefined);
         });
     t.equal(resizer.grab, null);
+    t.ok(resizer.onResizeStop.calledWith(resizer), 'should call onResizeStop');
 
     t.end();
 });


### PR DESCRIPTION
Add callback options `onResizeStart`, `onResize`, and `onResizeStop` for added control during the resize lifecycle.

Closes #6 
